### PR TITLE
Adding Private Key Detection Pre-Commit Hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,8 @@ repos:
         language: node
         pass_filenames: true
         types: [python]
+  -   repo: https://github.com/CoinAlpha/git-hooks
+      rev: 78f0683233a09c68a072fd52740d32c0376d4f0f
+      hooks:
+      -   id: detect-wallet-private-key
+          types: [file]


### PR DESCRIPTION
Adding this pre-commit hook not to commit private keys:

https://github.com/CoinAlpha/git-hooks/blob/main/src/hooks/detect_wallet_private_key.py

Also used by Humminbot.